### PR TITLE
Create schema for syn-ios-app project

### DIFF
--- a/sync-ios-app.xcodeproj/xcshareddata/xcschemes/sync-ios-app.xcscheme
+++ b/sync-ios-app.xcodeproj/xcshareddata/xcschemes/sync-ios-app.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4840C9D31C96F40C00140354"
+               BuildableName = "sync-ios-app.app"
+               BlueprintName = "sync-ios-app"
+               ReferencedContainer = "container:sync-ios-app.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4840C9E71C96F40C00140354"
+               BuildableName = "sync-ios-appTests.xctest"
+               BlueprintName = "sync-ios-appTests"
+               ReferencedContainer = "container:sync-ios-app.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4840C9F21C96F40C00140354"
+               BuildableName = "sync-ios-appUITests.xctest"
+               BlueprintName = "sync-ios-appUITests"
+               ReferencedContainer = "container:sync-ios-app.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4840C9D31C96F40C00140354"
+            BuildableName = "sync-ios-app.app"
+            BlueprintName = "sync-ios-app"
+            ReferencedContainer = "container:sync-ios-app.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4840C9D31C96F40C00140354"
+            BuildableName = "sync-ios-app.app"
+            BlueprintName = "sync-ios-app"
+            ReferencedContainer = "container:sync-ios-app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4840C9D31C96F40C00140354"
+            BuildableName = "sync-ios-app.app"
+            BlueprintName = "sync-ios-app"
+            ReferencedContainer = "container:sync-ios-app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Add missing schema.
Scheme are required when building CocoaPods project in BF or travis build.
@famer  as you can see I keep forgetting to add them :/
I've tested building this project on zeta BF it works just fine with the schema.
